### PR TITLE
update spectacle readme link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 ## Reference
 
-The Spectacle core API is available at [https://github.com/FormidableLabs/spectacle/blob/master/README.markdown](https://github.com/FormidableLabs/spectacle/blob/master/README.markdown).
+The Spectacle core API is available at [https://github.com/FormidableLabs/spectacle/blob/master/README.md](https://github.com/FormidableLabs/spectacle/blob/master/README.md).
 
 ## Development
 


### PR DESCRIPTION
fixes Spectacle readme 404

README.markdown
https://github.com/FormidableLabs/spectacle/blob/master/README.markdown
=>
https://github.com/FormidableLabs/spectacle/blob/master/README.md

renaming commit
https://github.com/FormidableLabs/spectacle/commit/3bb08da1d0564bd60896f2c742fb67e805f3994a#diff-04c6e90faac2675aa89e2176d2eec7d8

already updated in boilerplate
https://github.com/FormidableLabs/spectacle-boilerplate/issues/54